### PR TITLE
update tablist on heart blink and username style change

### DIFF
--- a/Shared/src/main/java/dev/tr7zw/exordium/mixin/PlayerTabOverlayMixin.java
+++ b/Shared/src/main/java/dev/tr7zw/exordium/mixin/PlayerTabOverlayMixin.java
@@ -16,7 +16,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import net.minecraft.client.gui.components.PlayerTabOverlay;
 import org.spongepowered.asm.mixin.Shadow;
 
-import java.sql.SQLType;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/Shared/src/main/java/dev/tr7zw/exordium/mixin/PlayerTabOverlayMixin.java
+++ b/Shared/src/main/java/dev/tr7zw/exordium/mixin/PlayerTabOverlayMixin.java
@@ -93,6 +93,7 @@ public abstract class PlayerTabOverlayMixin implements TablistAccess {
                 combinedHashes += playerInfo.getTabListDisplayName().getStyle().hashCode();
             }
             combinedHashes += playerInfo.getSkinLocation().hashCode();
+            combinedHashes += playerInfo.getLatency() * 63;
 
             if (lastTrackedObjective != null && lastTrackedObjective.getRenderType() == ObjectiveCriteria.RenderType.HEARTS) {
                 PlayerTabOverlay.HealthState healthState = this.healthStates.computeIfAbsent(playerInfo.getProfile().getId(), (uUID) ->

--- a/Shared/src/main/java/dev/tr7zw/exordium/mixin/PlayerTabOverlayMixin.java
+++ b/Shared/src/main/java/dev/tr7zw/exordium/mixin/PlayerTabOverlayMixin.java
@@ -7,8 +7,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.Style;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.scores.Objective;
 import net.minecraft.world.scores.Score;
 import net.minecraft.world.scores.Scoreboard;

--- a/Shared/src/main/java/dev/tr7zw/exordium/mixin/PlayerTabOverlayMixin.java
+++ b/Shared/src/main/java/dev/tr7zw/exordium/mixin/PlayerTabOverlayMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.Gui;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.scores.Objective;
 import net.minecraft.world.scores.Score;
 import net.minecraft.world.scores.Scoreboard;
@@ -79,16 +80,12 @@ public abstract class PlayerTabOverlayMixin implements TablistAccess {
     public int fastGetPlayerInfoListHashCode(List<PlayerInfo> playerInfos) {
         int hashCode = 1;
         for (PlayerInfo playerInfo : playerInfos) {
+            if (playerInfo == null) continue;
+
             int combinedHashes = 0;
-            if (playerInfo == null) {
-                hashCode *= 31;
-                continue;
-            }
             combinedHashes += playerInfo.getProfile().getId().hashCode();
             if (playerInfo.getTabListDisplayName() != null) {
                 combinedHashes += playerInfo.getTabListDisplayName().getString().hashCode();
-                Style displaynameStyle = playerInfo.getTabListDisplayName().getStyle();
-                combinedHashes += (displaynameStyle.getColor() == null ? 0 : displaynameStyle.getColor().getValue()) + (displaynameStyle.isBold() ? 1 : 0) + (displaynameStyle.isItalic() ? 3 : 0) + (displaynameStyle.isObfuscated() ? 7 : 0) + (displaynameStyle.isUnderlined() ? 15 : 0) + (displaynameStyle.isStrikethrough() ? 31 : 0);
                 combinedHashes += playerInfo.getTabListDisplayName().getStyle().hashCode();
             }
             combinedHashes += playerInfo.getSkinLocation().hashCode();

--- a/Shared/src/main/resources/exordium.accesswidener
+++ b/Shared/src/main/resources/exordium.accesswidener
@@ -1,3 +1,4 @@
 accessWidener	v1	named
 accessible field com/mojang/blaze3d/platform/GlStateManager BLEND Lcom/mojang/blaze3d/platform/GlStateManager$BlendState;
 accessible class com/mojang/blaze3d/platform/GlStateManager$BlendState
+accessible class net/minecraft/client/gui/components/PlayerTabOverlay$HealthState


### PR DESCRIPTION
Fixes the issue where the hearts get stuck blinking when showing the health scoreboard in the tablist also fixes updates now when the style of playerInfo.getTabListDisplayName() changes