### PR TITLE
Adhere to higher refresh rate displays

### DIFF
--- a/src/main/java/dev/tr7zw/exordium/config/ExordiumConfigScreen.java
+++ b/src/main/java/dev/tr7zw/exordium/config/ExordiumConfigScreen.java
@@ -64,7 +64,7 @@ public class ExordiumConfigScreen extends AbstractConfigScreen {
     private void addSettings(List<OptionInstance> options, Config.ComponentSettings settings, String name) {
         options.add(getOnOffOption("text.exordium.setting." + name + ".enabled", () -> settings.isEnabled(),
                 (b) -> settings.setEnabled(b)));
-        options.add(getIntOption("text.exordium.setting." + name + ".fps", 5, 60, () -> settings.getMaxFps(),
+        options.add(getIntOption("text.exordium.setting." + name + ".fps", 5, 240, () -> settings.getMaxFps(),
                 (v) -> settings.setMaxFps(v)));
     }
 


### PR DESCRIPTION
Removed the arbitrary limit of 60 fps and set it to 240 fps in order to adhere to players on high refresh rate displays and could not stand the 60 fps cap.

_I do get that this kinda breaks the spirit of the mod, but will definitely broaden the audience using Exordium!_